### PR TITLE
Add dbus, so commands like `timedatectl` and `localectl` will work.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
        sudo systemd systemd-sysv \
        build-essential wget libffi-dev libssl-dev procps \
        python3-pip python3-dev python3-setuptools python3-wheel python3-apt \
-       iproute2 \
+       iproute2 dbus \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean


### PR DESCRIPTION
Issue: https://github.com/geerlingguy/docker-debian12-ansible/issues/5

I recently ran into this issue trying to test something like this:
```yaml
- name: "Set timezone: {{ time_zone }}"
  become: true
  community.general.timezone:
    name: "{{ time_zone }}"
```

Which would fail, since `timedatectl` commands weren't working:
```
root@instance:/# timedatectl status
Failed to connect to bus: No such file or directory
```

So I tried this [person's advice](https://github.com/geerlingguy/docker-debian12-ansible/issues/5#issuecomment-1775354583), and it resolved the issue for me:
```
root@instance:/# timedatectl status
               Local time: Tue 2025-03-25 22:00:17 UTC
           Universal time: Tue 2025-03-25 22:00:17 UTC
                 RTC time: n/a
                Time zone: Etc/UTC (UTC, +0000)
System clock synchronized: yes
              NTP service: n/a
          RTC in local TZ: no
```